### PR TITLE
Improvements for the show-latest-build-versions script

### DIFF
--- a/show-latest-build-versions.sh
+++ b/show-latest-build-versions.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Set this to skip the podman pull
+FAST="${FAST:-""}"
+
 # Set this for verbose output
 VERBOSE="${VERBOSE:-""}"
 
@@ -16,7 +19,9 @@ _show_details() {
 	local ver="${3:-""}"
 
 	# Make sure we have the latest
-	podman pull --quiet $ref >/dev/null
+	if [ "$FAST" != "1" ]; then
+		podman pull --quiet $ref >/dev/null
+	fi
 
 	# Get the digest
 	local digest="$(skopeo inspect "docker://$ref" | jq -r .Digest)"

--- a/show-latest-build-versions.sh
+++ b/show-latest-build-versions.sh
@@ -4,20 +4,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-RH_TITLE="Red Hat Build"
-RH_REPO="registry.redhat.io/rhtas/ec-rhel9"
-RH_TAGS="${1:-"0.2 0.4 latest"}"
-
+# Set this for verbose output
 VERBOSE="${VERBOSE:-""}"
 
-UPSTREAM_TITLE="Upstream Build"
-UPSTREAM_REPO="quay.io/enterprise-contract/ec-cli"
-UPSTREAM_TAG="snapshot"
+# Update as required when we cut a new release or stop maintaining an old release
+RH_TAGS="${1:-"0.4 0.5 0.6"}"
 
 _show_details() {
 	local title="$1"
 	local ref="$2"
-	local ver="${3/./}"
+	local ver="${3:-""}"
 
 	# Make sure we have the latest
 	podman pull --quiet $ref >/dev/null
@@ -40,7 +36,7 @@ _show_details() {
 		echo Pinned ref:
 		echo "   $ref@$digest"
 
-		if [[ "$ver" =~ ^v0 ]]; then
+		if [[ -n "$ver" ]]; then
 			echo Likely Konflux build ref:
 			echo "   $konflux_image"
 		fi
@@ -59,15 +55,23 @@ _show_details() {
 	else
 		# Brief output
 		echo "$ref@$digest"
-		[[ "$ver" =~ ^v0 ]] && echo "$konflux_image"
+		[[ -n "$ver" ]] && echo "$konflux_image"
 		podman run --rm "$ref@$digest" version | sed 's/^/   /' | head -3
 		echo ""
 
 	fi
 }
 
+# Built and pushed by Konflux from a release branch
+# (This is shipped to customers with RHTAS)
 for t in ${RH_TAGS}; do
-	_show_details "$RH_TITLE ($t)" "$RH_REPO:$t" "v$t"
+	_show_details "Red Hat Build ($t)" "registry.redhat.io/rhtas/ec-rhel9:$t" "v${t/./}"
 done
 
-_show_details "$UPSTREAM_TITLE" "$UPSTREAM_REPO:$UPSTREAM_TAG" "main-ci"
+# Built/pushed by Konflux from main branch
+# (Used by Red Hat Konflux)
+_show_details "Main branch Konflux build" "quay.io/enterprise-contract/cli:latest" "main-ci"
+
+# Built/pushed by GitHub from main branch
+# (Maybe deprecated)
+_show_details "Main branch GitHub build" "quay.io/enterprise-contract/ec-cli:snapshot"


### PR DESCRIPTION
Include the new Konflux main branch build in the `show-latest-build-versions.sh` script.

Ref: [EC-913](https://issues.redhat.com/browse/EC-913)