### PR TITLE
ADD script to prune tags from quay.io

### DIFF
--- a/prune_quay_tags/README.md
+++ b/prune_quay_tags/README.md
@@ -1,0 +1,175 @@
+# Quay Tag Pruner
+
+A simple Bash script to list and delete [Quay.io](https://quay.io) repository image tags matching a given pattern that are older than a specified cutoff date. Supports dry-run mode to preview which tags *would* be deleted without actually removing them.
+
+---
+
+## Table of Contents
+
+- [Features](#features)  
+- [Prerequisites](#prerequisites)  
+- [Installation](#installation)  
+- [Usage](#usage)  
+  - [Required Arguments](#required-arguments)  
+  - [Date Filters](#date-filters)  
+  - [Token Authorization](#token-authorization)
+  - [Dry-Run Mode](#dry-run-mode)  
+- [Examples](#examples)  
+- [Authentication](#authentication)  
+- [Script Output](#script-output)  
+- [Exit Codes](#exit-codes)  
+- [Deleting Tags](#deleting-tags)
+- [License](#license)
+
+---
+## Features
+
+- **Filter** tags by name.  
+- **Filter** tags by age: either “N days old” or “before a specific date”.  
+- **Dry‑run** mode to preview which tags would be deleted.  
+- **Automatic** login detection via Docker, Podman, or Skopeo credential files.  
+- **Private** repositories supported via token authorization to get tags.
+- **Pagination** support for repositories with many tags.  
+
+---
+
+## Prerequisites
+
+Make sure the following commands are installed and available in your `PATH`:
+
+- [skopeo](https://github.com/containers/skopeo)  
+- [jq](https://stedolan.github.io/jq/)  
+- `curl`  
+- GNU `date` (for `-d` parsing)  
+
+---
+
+## Usage
+```
+./quay-tag-pruner.sh \
+  --repo    <org/repo> \
+  --filter  <string> \
+  [--days N | --before YYYY-MM-DD] \
+  [--token <string>] \
+  [--dry-run]
+```
+
+### Required Arguments
+
+* `--repo <org/repo>`  
+Quay repository path (e.g. myorg/myproject).
+
+* `--filter <string>`  
+Regular expression to match tag names (e.g. ^on-pr-).
+
+### Date Filters
+(one required)
+* `--days N`  
+Delete tags older than N days.
+
+* `--before YYYY-MM-DD`  
+Delete tags modified before the given date.
+
+### Token Authorization
+* `--token <string>`  
+A token string, used when accessing private repositories.  
+**Not** required for publicly accessible repositories.
+
+### Dry Run Mode
+* `--dry-run`  
+Only print which tags would be deleted; do not perform any deletions.
+
+## Examples
+
+**Preview** deletion of tags starting with on-pr- older than 30 days:
+
+```
+./quay-tag-pruner.sh \
+  --repo myorg/myrepo \
+  --filter 'on-pr-' \
+  --days 30 \
+  --dry-run
+```
+
+**Delete** tags matching release- modified before April 1, 2025:
+
+```
+./quay-tag-pruner.sh \
+  --repo myorg/myrepo \
+  --filter 'release-' \
+  --before 2025-04-01
+```
+
+**Delete** tags matching release- modified before April 1, 2025, from a private repo
+
+```
+./quay-tag-pruner.sh \
+  --repo myorg/myrepo \
+  --filter 'release-' \
+  --before 2025-04-01 \
+  --token 'THIS0IS1A3FAKE4TOKEN'
+```
+
+## Authentication
+The script checks for existing Quay.io credentials in:
+
+1. Docker (`~/.docker/config.json`)
+2. Podman/containers (`~/.config/containers/auth.json`)
+3. Skopeo runtime (`$XDG_RUNTIME_DIR/containers/auth.json`)
+
+If no credentials are found, log in with one of:
+
+**Docker**
+```
+$ docker login quay.io
+```
+**Podman**
+```
+$ podman login quay.io
+```
+**Skopeo**
+```
+$ skopeo login quay.io
+```
+
+## Script Output
+✅ deleted — tag deleted successfully  
+❌ failed — deletion attempted but failed  
+💡 would be deleted — in dry‑run mode  
+🔢 Total matching tags found  
+✅ Total tags deleted
+
+Each line is formatted as:
+```
+<tag-name> <YYYY-MM-DD HH:MM:SS TZ> <status>
+```
+
+## Exit Codes
+* 0 — Successful completion
+* 1 — Missing required argument or dependency, or authentication failure
+* \>1 — Unexpected error during execution
+
+## Deleting tags
+In Quay, when you delete a tag (whether via the API, the UI, or using a tool such as this), you are only removing the reference (the tag) to an image manifest. The underlying manifest and layer blobs remain in the registry until Quay’s garbage‐collection process reclaims them.
+
+> **NOTE**: What follows are few important notes regarding this script and deleting tags.
+
+* **Tag removal is immediate**  
+Once the DELETE call succeeds, the tag no longer appears in the tag listing and you can’t pull it by name anymore.
+
+* **Manifests live on until unreferenced**  
+If the deleted tag was the last one pointing at a given manifest, it becomes “orphaned.” Quay does not immediately purge the orphaned data.
+
+* **Reversion window (“time machine”)**  
+By default Quay holds deleted and expired tags (and their data) for 14 days, during which you can restore them via the UI or API (assuming your administrator hasn’t shortened that window).
+
+* **Asynchronous garbage collection**  
+Quay runs a background GC job that scans for unreferenced manifests and then physically deletes their blobs from storage.
+
+**So, in practice**:
+* DELETE tag → tag disappears immediately.
+* Quay GC (within its next cycle) → orphaned manifests and layers get cleaned up.
+* Before GC completes → you can still “undelete” or revert a tag if needed.
+
+## License
+This project is released under the Apache License, Version 2.0.

--- a/prune_quay_tags/prune_quay_tags.sh
+++ b/prune_quay_tags/prune_quay_tags.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+# Exit on error, undefined variable, or pipeline failure
+
+# ---------------------------
+# Ensure required commands are available
+# ---------------------------
+for cmd in skopeo jq curl date; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "❌ '$cmd' is not installed or not in your PATH. Please install $cmd."
+    exit 1
+  fi
+done
+
+# ---------------------------
+# Defaults for CLI arguments
+# ---------------------------
+REPO=""
+FILTER=""
+DAYS=""
+BEFORE=""
+QUAY_TOKEN=""
+DRY_RUN=false
+
+# ---------------------------
+# Parse flags
+# ---------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)    REPO="$2";         shift 2;;
+    --filter)  FILTER="$2";       shift 2;;
+    --days)    DAYS="$2";         shift 2;;
+    --before)  BEFORE="$2";       shift 2;;
+    --token)   QUAY_TOKEN="$2";   shift 2;;
+    --dry-run) DRY_RUN=true;      shift;;
+    *) echo "Usage: $0 --repo <repo> --filter <regex> [--days N | --before YYYY-MM-DD] [--token] [--dry-run]"; exit 1;;
+  esac
+done
+
+# ---------------------------
+# Validate required arguments
+# ---------------------------
+if [[ -z "$REPO" || -z "$FILTER" ]]; then
+  echo "❌ Missing --repo or --filter"
+  exit 1
+fi
+if [[ -z "$DAYS" && -z "$BEFORE" ]]; then
+  echo "❌ You must supply either --days or --before"
+  exit 1
+fi
+
+# ---------------------------
+# Compute cutoff epoch time
+# ---------------------------
+if [[ -n "$DAYS" ]]; then
+  CUTOFF=$(date -d "-$DAYS days" +%s)
+else
+  CUTOFF=$(date -d "$BEFORE" +%s)
+fi
+
+# ---------------------------
+# Echo context to user
+# ---------------------------
+echo "🔍 Repo:    $REPO"
+echo "🔎 Filter:  $FILTER"
+echo "📅 Cutoff:  Before $(date -d "@$CUTOFF" +'%Y-%m-%d %H:%M:%S %Z')"
+if [[ -n "${QUAY_TOKEN:-}" ]]; then
+  echo "🔑 Token:   ${QUAY_TOKEN:0:4}... (truncated)"
+fi
+$DRY_RUN && echo "🧪 Dry‑run: ON"
+
+# ---------------------------
+# Authentication check
+# ---------------------------
+# Look for quay.io credentials in various files
+if jq -e '.auths["quay.io"]' ~/.docker/config.json >/dev/null 2>&1; then
+  echo "✅ 🐋 Logged in via Docker credentials"
+# check to Podman/containers
+elif jq -e '."quay.io"' ~/.config/containers/auth.json >/dev/null 2>&1; then
+  echo "✅ 🦭 Logged in via containers/auth.json"
+# check Skopeo
+elif jq -e '.auths["quay.io"]' $XDG_RUNTIME_DIR/containers/auth.json >/dev/null 2>&1; then
+  echo "✅ 📦 Logged in via \$XDG_RUNTIME_DIR/containers/auth.json"
+# no creds? Suggest logging in
+else
+  echo "❌ No quay.io entry found in your credential files"
+  echo "Please log in to quay.io using Podman, Docker, or Skopeo first."
+  exit 1
+fi
+
+echo ""
+
+# ---------------------------
+# Pagination & tag fetching
+# ---------------------------
+PAGE=1
+BASE_URL="https://quay.io/api/v1/repository/${REPO}/tag/?limit=100"
+DELETED=0
+FOUND=0
+
+while :; do
+  # Set up curl arguments
+  # -s: silent mode
+  # -G: use GET method
+  curl_args=(-s -G)
+
+  # If we have a token, add it to the curl request as a header
+  # -H: add a header
+  if [[ -n "${QUAY_TOKEN:-}" ]]; then
+  curl_args+=( -H "Authorization: Bearer ${QUAY_TOKEN}" )
+  fi
+
+  # now append the URL + query args
+  # --data-urlencode: URL-encode the data
+  curl_args+=( "${BASE_URL}" \
+      --data-urlencode "page=${PAGE}" \
+      --data-urlencode "onlyActiveTags=true" \
+      --data-urlencode "filter_tag_name=like:${FILTER}" \
+  )
+
+  RESPONSE=$(curl "${curl_args[@]}")
+
+  # check for errors in the response:
+  if [[ "$(jq -r '.error' <<<"$RESPONSE")" != "null" ]]; then
+    echo "❌ Error fetching tags: $(jq -r '.error' <<<"$RESPONSE")"
+    exit 1
+  fi
+  # pull matching lines into a variable:
+  mapfile -t LINES < <(
+    echo "$RESPONSE" |
+        jq -r --arg f "$FILTER" '
+        .tags[]
+        | "\(.name)|\(.last_modified)"
+        '
+  )
+
+  [[ "$(jq -r '.has_additional' <<<"$RESPONSE")" == "true" ]] \
+    && ((PAGE++)) || break
+done
+
+# ---------------------------
+# Process each matching tag
+# ---------------------------
+for LINE in "${LINES[@]}"; do
+    IFS="|" read -r tag last_modified <<< "$LINE"
+    last_sec=$(date -d "$last_modified" +%s 2>/dev/null || echo 0)
+    if [[ "$last_sec" -lt "$CUTOFF" ]]; then
+        # add to the count of found tags, incrementing safely:
+        : $((FOUND++))
+        fmt=$(date -d "$last_modified" +"%Y-%m-%d %H:%M:%S %Z")
+        if $DRY_RUN; then
+          printf "%-80s %s 💡 would be deleted\n" "$tag" "$fmt"
+        else
+          if skopeo delete "docker://quay.io/${REPO}:${tag}" &> /dev/null; then
+            printf "%-80s %s ✅ deleted\n" "$tag" "$fmt"
+            # add to the count of deleted tags, incrementing safely:
+            : $((DELETED++))
+          else
+            printf "%-80s %s ❌ failed\n"  "$tag" "$fmt"
+          fi
+        fi
+    fi
+done
+
+echo ""
+# ---------------------------
+# Summary output
+# ---------------------------
+if $DRY_RUN; then
+  echo "🧪 Dry-run: would delete $FOUND tags matching “$FILTER”"
+else
+  echo "🔢 Total matching tags found: $FOUND"
+  echo "✅ Total tags deleted: $DELETED"
+fi


### PR DESCRIPTION
This commit adds the `prune_quay_tags.sh` script. The associated `README.md` documents the script, its usage, and applicable options.

REF: EC-977