### PR TITLE
chore: update references to ec-policies repo

### DIFF
--- a/provenance/README.md
+++ b/provenance/README.md
@@ -6,7 +6,7 @@ useful as reference as well as to assist development.
 ## Using the Recordings
 
 We can use a combination of [jq](https://jqlang.github.io/jq/) and the EC CLI to execute policy
-rules defined in ec-policies against the SLSA Provenance samples found in this repo.
+rules defined in conforma/policy against the SLSA Provenance samples found in this repo.
 
 In most cases, SLSA Provenance attestations are processed when evaluating an image. The EC CLI is
 responsible for fetching the attestations associated with the image. Below is an alternative

--- a/show-deployed-ec-policies.sh
+++ b/show-deployed-ec-policies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Run this script to quickly answer the question "What version of
-# ec-policies do we think is being used right now in Konflux?"
+# conforma/policy do we think is being used right now in Konflux?"
 #
 # Do it by looking in the applicable git repos, rather than inspecting
 # the cluster/clusters directly, which would probably be more dependable
@@ -16,7 +16,7 @@ APPLICABLE_REPOS="
   git@gitlab.cee.redhat.com:releng/konflux-release-data.git
 "
 
-EC_POLICIES="${PWD}/../ec-policies"
+EC_POLICIES="${PWD}/../policy"
 
 OPT_RAW="${1:-""}"
 


### PR DESCRIPTION
This commit updates references from the
`enterprise-contract/ec-policies` repo to `conforma/policy`.