### PR TITLE
chore(docs): update references to ec-cli

### DIFF
--- a/provenance/README.md
+++ b/provenance/README.md
@@ -25,7 +25,7 @@ ec validate input --policy policy.yaml \
 ```
 
 The important part of the command above is that it wraps the attestation into the
-[policy input](https://enterprisecontract.dev/docs/ec-cli/main/policy_input.html) format used by the
+[policy input](https://conforma.dev/docs/cli/policy_input.html) format used by the
 `ec validate image` command. This allows `release` policy rules to be used with the `validate input`
 command.
 


### PR DESCRIPTION
This commit updates references to ec-cli from `ec-cli` to `cli` as appropriate.

Ref: EC-1110