### PR TITLE
Add ubi-micro image to rpm version checker

### DIFF
--- a/rpm-version-checker.sh
+++ b/rpm-version-checker.sh
@@ -18,6 +18,8 @@ IMAGES_TO_CHECK=(
   registry.redhat.io/rhtas/ec-rhel9:0.7
   registry.redhat.io/rhtas/ec-rhel9:0.6
   registry.access.redhat.com/ubi9/ubi-minimal:latest
+  # ubi-micro is used by golden-image
+  registry.access.redhat.com/ubi9/ubi-micro:latest
 )
 
 RED="\e[31m✘\e[0m"


### PR DESCRIPTION
## Summary
- Add `registry.access.redhat.com/ubi9/ubi-micro:latest` to the list of images checked by `rpm-version-checker.sh`
- The ubi-micro base image is used by golden-image, so it should be included in RPM security update checks

## Test plan
- [ ] Run `./rpm-version-checker.sh` with a known RPM and verify ubi-micro is checked alongside the other images

🤖 Generated with [Claude Code](https://claude.com/claude-code)